### PR TITLE
refactor: centralize shared layout styles

### DIFF
--- a/ExclusaoChecklist/exclusao.css
+++ b/ExclusaoChecklist/exclusao.css
@@ -1,176 +1,3 @@
-@import url("../colors.css");
-
-/* ---------- RESET & BASE ---------- */
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-}
-
-/* ---------- HEADER ---------- */
-.header-container {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  font-size: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-
-.header-left h2 {
-  margin: 0;
-}
-
-.logo {
-  margin-top: 4px;
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-.sair {
-  text-decoration: none;
-  color: var(--dark-text-color);
-}
-
-/* ---------- NAV ---------- */
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.flags img {
-  margin-top: 4px;
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- MENU SUSPENSO ---------- */
-.menu-item {
-  position: relative;
-  cursor: pointer;
-}
-
-.submenu {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background-color: var(--light-color);
-  border: 1px solid var(--border-color);
-  box-shadow: 2px 2px 4px var(--shadow-sm);
-  border-radius: 6px;
-  padding: 10px 0;
-  z-index: 10;
-  min-width: 300px;
-}
-
-.submenu a {
-  display: block;
-  padding: 8px 20px;
-  color: var(--text-color);
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.submenu a:hover {
-  background-color: var(--muted-color);
-}
-
-.menu-item:hover .submenu {
-  display: block;
-}
-
-/* ---------- CONTAINER ---------- */
 .container {
   display: flex;
   justify-content: center;
@@ -210,7 +37,6 @@ nav {
   font-weight: bold;
 }
 
-/* ---------- FILTROS EM LINHA ---------- */
 .filters-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -246,7 +72,6 @@ select:focus {
   box-shadow: 0 0 3px rgba(62, 122, 183, 0.4);
 }
 
-/* ---------- AÇÕES ---------- */
 .form-actions {
   display: flex;
   justify-content: flex-end;
@@ -282,7 +107,6 @@ select:focus {
   background: var(--dark-151f2b);
 }
 
-/* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #1f1f1f;
   color: #e5e5e5;

--- a/ExclusaoChecklist/exclusao.html
+++ b/ExclusaoChecklist/exclusao.html
@@ -4,7 +4,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="/ExclusaoChecklist/exclusao.css">
+  <link rel="stylesheet" href="/styles/common.css" />
+  <link rel="stylesheet" href="/ExclusaoChecklist/exclusao.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos - Geração Checklist de Revisão</title>
 </head>
 

--- a/ExclusaoRevisao/index.html
+++ b/ExclusaoRevisao/index.html
@@ -4,7 +4,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="/ExclusaoRevisao/style.css">
+  <link rel="stylesheet" href="/styles/common.css" />
+  <link rel="stylesheet" href="/ExclusaoRevisao/style.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos - Exclusão de Checklist de Revisão</title>
 </head>
 

--- a/ExclusaoRevisao/style.css
+++ b/ExclusaoRevisao/style.css
@@ -1,166 +1,9 @@
-﻿@import url("../colors.css");
-
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-  font-family: "Open Sans", sans-serif;
-}
-
-/* ---------- HEADER ---------- */
-.header-container {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  font-size: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-.header-left h2 {
-  margin: 0;
-}
-.logo {
-  margin-top: 4px;
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-.sair {
-  text-decoration: none;
-  color: var(--dark-text-color);
-}
-
-/* ---------- NAV ---------- */
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.flags img {
-  margin-top: 4px;
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- MENU SUSPENSO ---------- */
-.menu-item {
-  position: relative;
-  cursor: pointer;
-}
-.submenu {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background-color: var(--light-color);
-  border: 1px solid var(--border-color);
-  box-shadow: 2px 2px 4px var(--shadow-sm);
-  border-radius: 6px;
-  padding: 10px 0;
-  z-index: 10;
-  min-width: 300px;
-}
-.submenu a {
-  display: block;
-  padding: 8px 20px;
-  color: var(--text-color);
-  text-decoration: none;
-  white-space: nowrap;
-}
-.submenu a:hover {
-  background-color: var(--muted-color);
-}
-.menu-item:hover .submenu {
-  display: block;
-}
-
-/* container (main) */
 .container {
   max-width: 1400px;
   margin-left: 280px;
   padding: 0 2rem;
 }
 
-/* Titulo */
 .page-header {
   margin-top: 20px;
   margin-bottom: 10px;
@@ -186,7 +29,6 @@ nav {
   background: var(--secondary-color);
 }
 
-/* ---------- PERÍODO ---------- */
 .periodo {
   border: 1px solid var(--border-color);
   border-radius: 10px;
@@ -223,10 +65,9 @@ input[type="number"] {
   border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 1rem;
-  height: 42px; /* altura fixa */
+  height: 42px;
 }
 
-/* ---------- LISTAS ---------- */
 .dual-list {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -268,7 +109,6 @@ input[type="number"] {
   background: #f9fafb;
 }
 
-/* ---------- BOTÕES ---------- */
 .dual-list .buttons {
   display: flex;
   flex-direction: column;
@@ -284,7 +124,7 @@ input[type="number"] {
   font-weight: 600;
   transition: all 0.2s;
   font-size: 1rem;
-  min-width: 120px; /* largura fixa para harmonia */
+  min-width: 120px;
 }
 .btn.primary {
   background: var(--accent-color);
@@ -359,7 +199,6 @@ select {
   text-align: center;
 }
 
-/* ---------- DARK MODE ---------- */
 body.dark-mode {
   background: var(--dark-bg);
   color: #e0e0e0;
@@ -394,7 +233,6 @@ body.dark-mode nav {
   border-bottom: 1px solid #333333;
 }
 
-/* PAINÉIS */
 body.dark-mode .periodo,
 body.dark-mode .list-box {
   background: var(--dark-accent);
@@ -405,14 +243,12 @@ body.dark-mode .list-box {
   transition: background 0.3s ease, transform 0.2s ease;
 }
 
-/* Títulos */
 body.dark-mode .periodo legend,
 body.dark-mode .list-box h2 {
   color: #f0c36d;
   font-weight: 600;
 }
 
-/* Inputs */
 body.dark-mode input[type="number"] {
   background: #2b2b2b;
   border: 1px solid #3a3a3a;
@@ -424,7 +260,6 @@ body.dark-mode input[type="number"]::placeholder {
   color: #777;
 }
 
-/* Listas */
 body.dark-mode .list {
   background: #2a2a2a;
   color: #e0e0e0;
@@ -435,7 +270,6 @@ body.dark-mode .list:hover {
   background: #323232;
 }
 
-/* Botões */
 body.dark-mode .btn.primary:hover {
   background: #d9a84a;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);

--- a/GerarChecklist/checklist.css
+++ b/GerarChecklist/checklist.css
@@ -1,176 +1,3 @@
-@import url("../colors.css");
-
-/* ---------- RESET & BASE ---------- */
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-}
-
-/* ---------- HEADER ---------- */
-.header-container {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  font-size: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-
-.header-left h2 {
-  margin: 0;
-}
-
-.logo {
-  margin-top: 4px;
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-.sair {
-  text-decoration: none;
-  color: var(--dark-text-color);
-}
-
-/* ---------- NAV ---------- */
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.flags img {
-  margin-top: 4px;
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- MENU SUSPENSO ---------- */
-.menu-item {
-  position: relative;
-  cursor: pointer;
-}
-
-.submenu {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background-color: var(--light-color);
-  border: 1px solid var(--border-color);
-  box-shadow: 2px 2px 4px var(--shadow-sm);
-  border-radius: 6px;
-  padding: 10px 0;
-  z-index: 10;
-  min-width: 300px;
-}
-
-.submenu a {
-  display: block;
-  padding: 8px 20px;
-  color: var(--text-color);
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.submenu a:hover {
-  background-color: var(--muted-color);
-}
-
-.menu-item:hover .submenu {
-  display: block;
-}
-
-/* ---------- CONTAINER ---------- */
 .container {
   display: flex;
   justify-content: center;
@@ -208,7 +35,6 @@ nav {
   font-weight: bold;
 }
 
-/* ---------- FILTROS ---------- */
 .filters-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -250,7 +76,6 @@ select:focus {
   box-shadow: 0 0 3px rgba(62, 122, 183, 0.4);
 }
 
-/* ---------- AÇÕES ---------- */
 .form-actions {
   display: flex;
   justify-content: flex-end;
@@ -286,7 +111,6 @@ select:focus {
   background: var(--dark-151f2b);
 }
 
-/* ---------- SEM ABAS ---------- */
 .tab-content {
   display: block;
   padding: 0;
@@ -295,7 +119,6 @@ select:focus {
   box-shadow: none;
 }
 
-/* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #1f1f1f;
   color: #e5e5e5;

--- a/GerarChecklist/checklist.html
+++ b/GerarChecklist/checklist.html
@@ -4,7 +4,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="/GerarChecklist/checklist.css">
+  <link rel="stylesheet" href="/styles/common.css" />
+  <link rel="stylesheet" href="/GerarChecklist/checklist.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos - Geração Checklist de Impostos</title>
 </head>
 

--- a/calendario/calendario.html
+++ b/calendario/calendario.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/styles/common.css" />
   <link rel="stylesheet" href="/calendario/processos.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos - Geração de Calendário</title>
 </head>

--- a/calendario/processos.css
+++ b/calendario/processos.css
@@ -1,159 +1,3 @@
-@import url("../colors.css");
-
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-  font-family: "Open Sans", sans-serif;
-}
-
-/* ---------- HEADER ---------- */
-.header-container {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  font-size: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-.header-left h2 {
-  margin: 0;
-}
-.logo {
-  margin-top: 4px;
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-.sair {
-  text-decoration: none;
-  color: var(--dark-text-color);
-}
-
-/* ---------- NAV ---------- */
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.flags img {
-  margin-top: 4px;
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- MENU SUSPENSO ---------- */
-.menu-item {
-  position: relative;
-  cursor: pointer;
-}
-.submenu {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background-color: var(--light-color);
-  border: 1px solid var(--border-color);
-  box-shadow: 2px 2px 4px var(--shadow-sm);
-  border-radius: 6px;
-  padding: 10px 0;
-  z-index: 10;
-  min-width: 300px;
-}
-.submenu a {
-  display: block;
-  padding: 8px 20px;
-  color: var(--text-color);
-  text-decoration: none;
-  white-space: nowrap;
-}
-.submenu a:hover {
-  background-color: var(--muted-color);
-}
-.menu-item:hover .submenu {
-  display: block;
-}
-
-/* ---------- CONTEÚDO ---------- */
 .container {
   max-width: 1400px;
   margin-left: 280px;
@@ -187,7 +31,6 @@ nav {
   background: var(--secondary-color);
 }
 
-/* ---------- PERÍODO ---------- */
 .periodo {
   border: 1px solid var(--border-color);
   border-radius: 10px;
@@ -224,10 +67,9 @@ input[type="number"] {
   border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 1rem;
-  height: 42px; /* altura fixa */
+  height: 42px;
 }
 
-/* ---------- LISTAS ---------- */
 .dual-list {
   display: grid;
   grid-template-columns: 1fr 160px 1fr;
@@ -266,7 +108,6 @@ input[type="number"] {
   background: #f9fafb;
 }
 
-/* ---------- BOTÕES ---------- */
 .btn {
   border: none;
   border-radius: 8px;
@@ -322,7 +163,6 @@ input[type="number"] {
   align-items: center;
 }
 
-/* ---------- INFO ---------- */
 .info {
   margin-top: 2rem;
   padding: 1.2rem 1.5rem;
@@ -344,7 +184,6 @@ input[type="number"] {
   margin-bottom: 0;
 }
 
-/* ---------- DARK MODE ---------- */
 body.dark-mode {
   background: var(--dark-bg);
   color: #e0e0e0;
@@ -379,7 +218,6 @@ body.dark-mode nav {
   border-bottom: 1px solid #333333;
 }
 
-/* PAINÉIS */
 body.dark-mode .periodo,
 body.dark-mode .list-box {
   background: var(--dark-accent);
@@ -390,14 +228,12 @@ body.dark-mode .list-box {
   transition: background 0.3s ease, transform 0.2s ease;
 }
 
-/* Títulos */
 body.dark-mode .periodo legend,
 body.dark-mode .list-box h2 {
   color: #f0c36d;
   font-weight: 600;
 }
 
-/* Inputs */
 body.dark-mode input[type="number"] {
   background: #2b2b2b;
   border: 1px solid #3a3a3a;
@@ -409,7 +245,6 @@ body.dark-mode input[type="number"]::placeholder {
   color: #777;
 }
 
-/* Listas */
 body.dark-mode .list {
   background: #2a2a2a;
   color: #e0e0e0;
@@ -420,7 +255,6 @@ body.dark-mode .list:hover {
   background: #323232;
 }
 
-/* Botões */
 body.dark-mode .btn.primary:hover {
   background: #d9a84a;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);

--- a/capaprocesso/capa-de-processo.css
+++ b/capaprocesso/capa-de-processo.css
@@ -1,182 +1,3 @@
-@import url("../colors.css");
-
-/* ---------- RESET E BASE ---------- */
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-  font-family: "Open Sans", sans-serif;
-}
-
-/* ---------- HEADER ---------- */
-header {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  padding: 12px 24px;
-  font-size: 20px;
-}
-.header-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-.header-left h2 {
-  margin: 0;
-}
-.logo {
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-/* ---------- FAROL DE STATUS ---------- */
-
-.farol {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  display: inline-block;
-}
-
-.farol:hover {
-  transform: scale(1.35);
-  box-shadow: 0 0 8px 2px var(--shadow-md);
-}
-
-.farol.complementar,
-.complementar::before {
-  background-color: var(--link-color);
-  cursor: pointer;
-}
-
-.farol.todos-os-status,
-.todos-os-status::before {
-  background-color: var(--dark-gray);
-  cursor: pointer;
-}
-
-.farol.retificacao,
-.retificacao::before {
-  background-color: var(--danger-color);
-  cursor: pointer;
-}
-.farol.dentro-prazo,
-.dentro-prazo::before {
-  background-color: var(--status-dentro-prazo);
-  cursor: pointer;
-}
-.farol.no-limite,
-.no-limite::before {
-  background-color: var(--status-no-limite);
-  cursor: pointer;
-}
-.farol.vencido,
-.vencido::before {
-  background-color: var(--status-vencido);
-  cursor: pointer;
-}
-.farol.finalizado,
-.finalizado::before {
-  background-color: var(--status-finalizado);
-  cursor: pointer;
-}
-.farol.fora-prazo,
-.fora-prazo::before {
-  background-color: var(--status-fora-prazo);
-  cursor: pointer;
-}
-
-/* ---------- Navegação ---------- */
-
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.flags img {
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- CONTAINER & SECTIONS ---------- */
 .container,
 .section-ct {
   background-color: var(--overlay-dark);
@@ -191,7 +12,6 @@ nav {
   box-shadow: 0 2px 4px var(--shadow-sm);
 }
 
-/* ---------- FILTROS & GRÁFICOS ---------- */
 .filtros-e-grafico {
   display: flex;
 }
@@ -233,7 +53,6 @@ nav {
   margin-bottom: 12px;
   text-align: center;
 }
-/* ---------- FILTROS - FORMULÁRIOS ---------- */
 .painel-geral {
   display: flex;
   gap: 10px;
@@ -323,7 +142,6 @@ nav {
   text-align: center;
 }
 
-/* ---------- FORM HEADER ---------- */
 .form-header {
   display: flex;
   justify-content: space-between;
@@ -342,12 +160,11 @@ nav {
   margin: 0;
 }
 
-/* ---------- ASSOCIAR RESPONSÁVEL ---------- */
 
 .fitros-consulta.associar-responsavel {
   display: flex;
   flex-direction: column;
-  align-items: flex-start; /* Deixa tudo alinhado à esquerda */
+  align-items: flex-start;
   gap: 0;
   margin: 0;
   padding: 0;
@@ -359,7 +176,7 @@ nav {
   font-size: 14px;
   margin: 0 0 2px 0;
   padding: 0;
-  var(--light-color)-space: nowrap;
+  white-space: nowrap;
 }
 
 .grupo-associar {
@@ -399,7 +216,6 @@ nav {
   background-color: var(--gray-da);
 }
 
-/* ---------- BUTTONS ---------- */
 .consulta,
 .associar-responsavel button,
 .archives,
@@ -430,7 +246,6 @@ nav {
   font-weight: 500;
 }
 
-/* Modal anexos */
 
 .modal {
   display: none;
@@ -496,7 +311,6 @@ nav {
   padding-bottom: 8px;
 }
 
-/* Botão principal */
 .btn-download-todos {
   display: inline-block;
   background-color: var(--secondary-color);
@@ -515,7 +329,6 @@ nav {
   background-color: var(--secondary-color);
 }
 
-/* Tabela com anexos */
 .tabela-anexos {
   display: flex;
   flex-direction: column;
@@ -570,13 +383,11 @@ nav {
   text-decoration: underline;
 }
 
-/* Checkbox */
 .tabela-anexos input[type="checkbox"] {
   transform: scale(1.1);
   cursor: pointer;
 }
 
-/* Scroll estilizado */
 .tabela-anexos::-webkit-scrollbar {
   width: 6px;
 }
@@ -755,7 +566,6 @@ nav {
   cursor: pointer;
 }
 
-/* ---------- LEGENDAS E INDICADORES ---------- */
 .linha-legenda-botoes {
   display: flex;
   align-items: center;
@@ -839,7 +649,6 @@ nav {
   cursor: pointer;
 }
 
-/* ---------- TABLES ---------- */
 table {
   width: 100%;
   border-collapse: collapse;
@@ -880,7 +689,6 @@ th {
   background-color: var(--link-color);
 }
 
-/* ---------- MENU SUSPENSO ---------- */
 .menu-item {
   position: relative;
   cursor: pointer;
@@ -912,7 +720,6 @@ th {
   display: block;
 }
 
-/* ---------- RESPONSIVO ---------- */
 @media (max-width: 768px) {
   .consulta-geral {
     flex-direction: column;
@@ -923,7 +730,6 @@ th {
   }
 }
 
-/* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: var(--gray-900);
   color: var(--muted-color);

--- a/capaprocesso/capa-de-processo.html
+++ b/capaprocesso/capa-de-processo.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/styles/common.css" />
   <link rel="stylesheet" href="/capaprocesso/capa-de-processo.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos</title>
 </head>

--- a/consultas/operativo.css
+++ b/consultas/operativo.css
@@ -1,186 +1,3 @@
-@import url("../colors.css");
-
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-  font-family: "Open Sans", sans-serif;
-}
-
-/* ---------- HEADER ---------- */
-header {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  padding: 12px 24px;
-  font-size: 20px;
-}
-.header-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-.header-left h2 {
-  margin: 0;
-}
-.logo {
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-.sair {
-  text-decoration: none;
-  color: var(--dark-text-color);
-}
-
-/* ---------- FAROL DE STATUS ---------- */
-
-.farol {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  display: inline-block;
-}
-
-.farol:hover {
-  transform: scale(1.35);
-  box-shadow: 0 0 8px 2px var(--shadow-md);
-}
-
-.farol.complementar,
-.complementar::before {
-  background-color: var(--link-color);
-  cursor: pointer;
-}
-
-.farol.todos-os-status,
-.todos-os-status::before {
-  background-color: var(--dark-gray);
-  cursor: pointer;
-}
-
-.farol.retificacao,
-.retificacao::before {
-  background-color: var(--danger-color);
-  cursor: pointer;
-}
-.farol.dentro-prazo,
-.dentro-prazo::before {
-  background-color: var(--status-dentro-prazo);
-  cursor: pointer;
-}
-.farol.no-limite,
-.no-limite::before {
-  background-color: var(--status-no-limite);
-  cursor: pointer;
-}
-.farol.vencido,
-.vencido::before {
-  background-color: var(--status-vencido);
-  cursor: pointer;
-}
-.farol.finalizado,
-.finalizado::before {
-  background-color: var(--status-finalizado);
-  cursor: pointer;
-}
-.farol.fora-prazo,
-.fora-prazo::before {
-  background-color: var(--status-fora-prazo);
-  cursor: pointer;
-}
-
-/* ---------- Navegação ---------- */
-
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.flags img {
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- CONTAINER & SECTIONS ---------- */
 .container,
 .section-ct {
   background-color: var(--overlay-dark);
@@ -204,7 +21,6 @@ nav {
   box-shadow: 0 2px 4px var(--shadow-sm);
 }
 
-/* ---------- FILTROS & GRÁFICOS ---------- */
 .filtros-e-grafico {
   display: flex;
 }
@@ -255,7 +71,6 @@ nav {
   font-size: 16px;
 }
 
-/* ---------- FILTROS - FORMULÁRIOS ---------- */
 .painel-geral {
   display: flex;
   gap: 10px;
@@ -348,7 +163,6 @@ nav {
   text-align: center;
 }
 
-/* ---------- FORM HEADER ---------- */
 .form-header {
   display: flex;
   justify-content: space-between;
@@ -367,7 +181,6 @@ nav {
   margin: 0;
 }
 
-/* ---------- BUTTONS ---------- */
 .consulta,
 .associar-responsavel button,
 .archives,
@@ -398,7 +211,6 @@ nav {
   font-weight: 500;
 }
 
-/* Modal anexos */
 
 .modal {
   display: none;
@@ -464,7 +276,6 @@ nav {
   padding-bottom: 8px;
 }
 
-/* Botão principal */
 .btn-download-todos {
   display: inline-block;
   background-color: var(--secondary-color);
@@ -483,7 +294,6 @@ nav {
   background-color: var(--secondary-color);
 }
 
-/* Tabela com anexos */
 .tabela-anexos {
   display: flex;
   flex-direction: column;
@@ -538,13 +348,11 @@ nav {
   text-decoration: underline;
 }
 
-/* Checkbox */
 .tabela-anexos input[type="checkbox"] {
   transform: scale(1.1);
   cursor: pointer;
 }
 
-/* Scroll estilizado */
 .tabela-anexos::-webkit-scrollbar {
   width: 6px;
 }
@@ -721,7 +529,6 @@ nav {
   cursor: pointer;
 }
 
-/* ---------- LEGENDAS E INDICADORES ---------- */
 .linha-legenda-botoes {
   display: flex;
   align-items: center;
@@ -803,7 +610,6 @@ nav {
   cursor: pointer;
 }
 
-/* ---------- TABLES ---------- */
 table {
   width: 100%;
   border-collapse: collapse;
@@ -879,7 +685,6 @@ th {
   color: var(--light-color);
 }
 
-/* ---------- MENU SUSPENSO ---------- */
 .menu-item {
   position: relative;
   cursor: pointer;
@@ -911,7 +716,6 @@ th {
   display: block;
 }
 
-/* ---------- RESPONSIVO ---------- */
 @media (max-width: 768px) {
   .consulta-geral {
     flex-direction: column;
@@ -922,7 +726,6 @@ th {
   }
 }
 
-/* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: var(--gray-900);
   color: var(--muted-color);

--- a/consultas/operativo.html
+++ b/consultas/operativo.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/styles/common.css" />
   <link rel="stylesheet" href="/consultas/operativo.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos</title>
 </head>

--- a/consultas/supervisor.css
+++ b/consultas/supervisor.css
@@ -1,187 +1,3 @@
-@import url("../colors.css");
-
-/* ---------- RESET E BASE ---------- */
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-  font-family: "Open Sans", sans-serif;
-}
-
-/* ---------- HEADER ---------- */
-header {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  padding: 12px 24px;
-  font-size: 20px;
-}
-.header-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-.header-left h2 {
-  margin: 0;
-}
-.logo {
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-.sair {
-  text-decoration: none;
-  color: var(--dark-text-color);
-}
-
-/* ---------- FAROL DE STATUS ---------- */
-
-.farol {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  display: inline-block;
-}
-
-.farol:hover {
-  transform: scale(1.35);
-  box-shadow: 0 0 8px 2px var(--shadow-md);
-}
-
-.farol.complementar,
-.complementar::before {
-  background-color: var(--link-color);
-  cursor: pointer;
-}
-
-.farol.todos-os-status,
-.todos-os-status::before {
-  background-color: var(--dark-gray);
-  cursor: pointer;
-}
-
-.farol.retificacao,
-.retificacao::before {
-  background-color: var(--danger-color);
-  cursor: pointer;
-}
-.farol.dentro-prazo,
-.dentro-prazo::before {
-  background-color: var(--status-dentro-prazo);
-  cursor: pointer;
-}
-.farol.no-limite,
-.no-limite::before {
-  background-color: var(--status-no-limite);
-  cursor: pointer;
-}
-.farol.vencido,
-.vencido::before {
-  background-color: var(--status-vencido);
-  cursor: pointer;
-}
-.farol.finalizado,
-.finalizado::before {
-  background-color: var(--status-finalizado);
-  cursor: pointer;
-}
-.farol.fora-prazo,
-.fora-prazo::before {
-  background-color: var(--status-fora-prazo);
-  cursor: pointer;
-}
-
-/* ---------- Navegação ---------- */
-
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.flags img {
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- CONTAINER & SECTIONS ---------- */
 .container,
 .section-ct {
   background-color: var(--overlay-dark);
@@ -205,7 +21,6 @@ nav {
   box-shadow: 0 2px 4px var(--shadow-sm);
 }
 
-/* ---------- FILTROS & GRÁFICOS ---------- */
 .filtros-e-grafico {
   display: flex;
 }
@@ -272,7 +87,6 @@ nav {
   transition: width 0s;
 }
 
-/* ---------- FILTROS - FORMULÁRIOS ---------- */
 .painel-geral {
   display: flex;
   gap: 10px;
@@ -365,7 +179,6 @@ nav {
   text-align: center;
 }
 
-/* ---------- FORM HEADER ---------- */
 .form-header {
   display: flex;
   justify-content: space-between;
@@ -384,7 +197,6 @@ nav {
   margin: 0;
 }
 
-/* ---------- BUTTONS ---------- */
 .consulta,
 .associar-responsavel button,
 .archives,
@@ -435,7 +247,6 @@ nav {
   font-weight: 500;
 }
 
-/* Modal anexos */
 
 .modal {
   display: none;
@@ -501,7 +312,6 @@ nav {
   padding-bottom: 8px;
 }
 
-/* Botão principal */
 .btn-download-todos {
   display: inline-block;
   background-color: var(--secondary-color);
@@ -520,7 +330,6 @@ nav {
   background-color: var(--secondary-color);
 }
 
-/* Tabela com anexos */
 .tabela-anexos {
   display: flex;
   flex-direction: column;
@@ -575,13 +384,11 @@ nav {
   text-decoration: underline;
 }
 
-/* Checkbox */
 .tabela-anexos input[type="checkbox"] {
   transform: scale(1.1);
   cursor: pointer;
 }
 
-/* Scroll estilizado */
 .tabela-anexos::-webkit-scrollbar {
   width: 6px;
 }
@@ -775,7 +582,6 @@ nav {
   cursor: pointer;
 }
 
-/* ---------- LEGENDAS E INDICADORES ---------- */
 .linha-legenda-botoes {
   display: flex;
   align-items: center;
@@ -857,7 +663,6 @@ nav {
   cursor: pointer;
 }
 
-/* ---------- TABLES ---------- */
 table {
   width: 100%;
   border-collapse: collapse;
@@ -933,7 +738,6 @@ th {
   color: var(--light-color);
 }
 
-/* ---------- MENU SUSPENSO ---------- */
 .menu-item {
   position: relative;
   cursor: pointer;
@@ -965,7 +769,6 @@ th {
   display: block;
 }
 
-/* ---------- RESPONSIVO ---------- */
 @media (max-width: 768px) {
   .consulta-geral {
     flex-direction: column;
@@ -976,7 +779,6 @@ th {
   }
 }
 
-/* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: var(--gray-900);
   color: var(--muted-color);

--- a/consultas/supervisor.html
+++ b/consultas/supervisor.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/styles/common.css" />
   <link rel="stylesheet" href="/consultas/supervisor.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos</title>
 </head>

--- a/revisão/revisao.css
+++ b/revisão/revisao.css
@@ -1,165 +1,8 @@
-@import url("../colors.css");
-
-* {
-  box-sizing: border-box;
-  font-family: "Open Sans", sans-serif;
-}
-body {
-  margin: 0;
-  background-color: var(--background-color);
-  color: var(--text-color);
-  font-family: "Open Sans", sans-serif;
-}
-
-/* ---------- HEADER ---------- */
-.header-container {
-  background-color: var(--primary-color);
-  color: var(--light-color);
-  font-size: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 3px solid var(--secondary-color);
-  padding: 8px 16px;
-}
-.header-left h2 {
-  margin: 0;
-}
-.logo {
-  margin-top: 4px;
-  height: 40px;
-  max-width: 100%;
-  object-fit: contain;
-}
-.mainmenu {
-  text-decoration: none;
-  color: var(--light-color);
-}
-
-.sair {
-  text-decoration: none;
-  color: var(--dark-text-color);
-}
-
-/* ---------- NAV ---------- */
-nav {
-  background-color: var(--muted-color);
-  padding: 10px 20px;
-  display: flex;
-  gap: 20px;
-  font-weight: bold;
-  border-bottom: 1px solid var(--border-color);
-  position: relative;
-  font-size: 18px;
-}
-.nav-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.nav-left,
-.nav-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.flags img {
-  margin-top: 4px;
-  width: 24px;
-  height: auto;
-  cursor: pointer;
-}
-
-/* ---------- TOGGLE SWITCH ---------- */
-.toggle-switch {
-  position: relative;
-  width: 45px;
-  height: 22px;
-  --light: var(--toggle-light);
-  --dark: var(--toggle-dark);
-  --link: var(--toggle-link);
-  --link-hover: var(--toggle-link-hover);
-}
-.switch-label {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dark);
-  cursor: pointer;
-  border-radius: 11px;
-  border: 2px solid var(--dark);
-}
-.checkbox {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 11px;
-  transition: background-color 0.3s ease;
-}
-.checkbox:checked ~ .slider {
-  background-color: var(--light);
-}
-.slider::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-color: var(--dark);
-  box-shadow: inset 8px -3px 0 0 var(--light);
-  transition: transform 0.3s ease;
-}
-.checkbox:checked ~ .slider::before {
-  transform: translateX(23px);
-}
-
-/* ---------- MENU SUSPENSO ---------- */
-.menu-item {
-  position: relative;
-  cursor: pointer;
-}
-.submenu {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background-color: var(--light-color);
-  border: 1px solid var(--border-color);
-  box-shadow: 2px 2px 4px var(--shadow-sm);
-  border-radius: 6px;
-  padding: 10px 0;
-  z-index: 10;
-  min-width: 300px;
-}
-.submenu a {
-  display: block;
-  padding: 8px 20px;
-  color: var(--text-color);
-  text-decoration: none;
-  white-space: nowrap;
-}
-.submenu a:hover {
-  background-color: var(--muted-color);
-}
-.menu-item:hover .submenu {
-  display: block;
-}
-
-/* Container principal */
 .container {
   padding: 1.5rem;
   color: var(--text-color);
 }
 
-/* Título */
 .title {
   margin-top: -10px;
   margin-bottom: 10px;
@@ -252,7 +95,6 @@ nav {
   background: var(--light-color);
 }
 
-/* Botões */
 .btn {
   border: none;
   border-radius: 6px;
@@ -301,7 +143,6 @@ nav {
   background: var(--gray-700);
 }
 
-/* ---------------- DARK MODE ---------------- */
 body.dark-mode {
   background: var(--dark-bg);
   color: var(--gray-200);

--- a/revisão/revisao.html
+++ b/revisão/revisao.html
@@ -4,7 +4,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="/revisão/revisao.css">
+  <link rel="stylesheet" href="/styles/common.css" />
+  <link rel="stylesheet" href="/revisão/revisao.css" />
   <title>PZMWEB Enterprise :: Controle de Impostos - Geração Checklist de Revisão</title>
 </head>
 

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,0 +1,227 @@
+@import url("../colors.css");
+
+* {
+  box-sizing: border-box;
+  font-family: "Open Sans", sans-serif;
+}
+
+body {
+  margin: 0;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: "Open Sans", sans-serif;
+}
+
+.header-container {
+  background-color: var(--primary-color);
+  color: var(--light-color);
+  font-size: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 3px solid var(--secondary-color);
+  padding: 8px 16px;
+}
+
+.header-left h2 {
+  margin: 0;
+}
+
+.logo {
+  margin-top: 4px;
+  height: 40px;
+  max-width: 100%;
+  object-fit: contain;
+}
+
+.mainmenu {
+  color: var(--light-color);
+  text-decoration: none;
+}
+
+.sair {
+  color: var(--dark-text-color);
+  text-decoration: none;
+}
+
+nav {
+  background-color: var(--muted-color);
+  padding: 10px 20px;
+  display: flex;
+  gap: 20px;
+  font-weight: bold;
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+  font-size: 18px;
+}
+
+.nav-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-left,
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.flags img {
+  margin-top: 4px;
+  width: 24px;
+  height: auto;
+  cursor: pointer;
+}
+
+.toggle-switch {
+  position: relative;
+  width: 45px;
+  height: 22px;
+  --light: var(--toggle-light);
+  --dark: var(--toggle-dark);
+  --link: var(--toggle-link);
+  --link-hover: var(--toggle-link-hover);
+}
+
+.switch-label {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: var(--dark);
+  cursor: pointer;
+  border-radius: 11px;
+  border: 2px solid var(--dark);
+}
+
+.checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 11px;
+  transition: background-color 0.3s ease;
+}
+
+.checkbox:checked ~ .slider {
+  background-color: var(--light);
+}
+
+.slider::before {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: var(--dark);
+  box-shadow: inset 8px -3px 0 0 var(--light);
+  transition: transform 0.3s ease;
+}
+
+.checkbox:checked ~ .slider::before {
+  transform: translateX(23px);
+}
+
+.menu-item {
+  position: relative;
+  cursor: pointer;
+}
+
+.submenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
+  box-shadow: 2px 2px 4px var(--shadow-sm);
+  border-radius: 6px;
+  padding: 10px 0;
+  z-index: 10;
+  min-width: 300px;
+}
+
+.submenu a {
+  display: block;
+  padding: 8px 20px;
+  color: var(--text-color);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.submenu a:hover {
+  background-color: var(--muted-color);
+}
+
+.menu-item:hover .submenu {
+  display: block;
+}
+
+.farol {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.farol:hover {
+  transform: scale(1.35);
+  box-shadow: 0 0 8px 2px var(--shadow-md);
+}
+
+.farol.complementar,
+.complementar::before {
+  background-color: var(--link-color);
+  cursor: pointer;
+}
+
+.farol.todos-os-status,
+.todos-os-status::before {
+  background-color: var(--dark-gray);
+  cursor: pointer;
+}
+
+.farol.retificacao,
+.retificacao::before {
+  background-color: var(--danger-color);
+  cursor: pointer;
+}
+
+.farol.dentro-prazo,
+.dentro-prazo::before {
+  background-color: var(--status-dentro-prazo);
+  cursor: pointer;
+}
+
+.farol.no-limite,
+.no-limite::before {
+  background-color: var(--status-no-limite);
+  cursor: pointer;
+}
+
+.farol.vencido,
+.vencido::before {
+  background-color: var(--status-vencido);
+  cursor: pointer;
+}
+
+.farol.finalizado,
+.finalizado::before {
+  background-color: var(--status-finalizado);
+  cursor: pointer;
+}
+
+.farol.fora-prazo,
+.fora-prazo::before {
+  background-color: var(--status-fora-prazo);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- create a shared stylesheet with the header, navigation, toggle, and status styles that were duplicated across the pages
- clean up the individual page styles by removing redundant rules/comments and fixing the stray white-space rule
- update every HTML page to load the shared stylesheet so the common styles remain applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d16bcc6d708330940ea10ea64dec35